### PR TITLE
Remove archived module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -420,16 +420,6 @@
     "isCore": false
   },
   {
-    "github": "silverstripe/silverstripe-controllerpolicy",
-    "gitlab": null,
-    "composer": "silverstripe/controllerpolicy",
-    "scrutinizer": true,
-    "addons": true,
-    "type": "supported-module",
-    "githubId": 19681209,
-    "isCore": false
-  },
-  {
     "github": "silverstripe/silverstripe-crontask",
     "gitlab": null,
     "composer": "silverstripe/crontask",


### PR DESCRIPTION
https://github.com/silverstripe/silverstripe-controllerpolicy is archived. It is most definitely not supported.

Having this here is resulting in an untriaged issue showing in Elvis, but we can't triage it.